### PR TITLE
fix(createPledge): Use refetchQuery

### DIFF
--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -2,32 +2,7 @@ import { graphql, compose } from 'react-apollo';
 import gql from 'graphql-tag';
 import { pick, isArray } from 'lodash';
 
-import { getLoggedInUserQuery, getCollectiveToEditQueryFields, getCollectiveQuery } from './queries';
-
-const createOrderQuery = gql`
-  mutation createOrder($order: OrderInputType!) {
-    createOrder(order: $order) {
-      id
-      createdAt
-      status
-      createdByUser {
-        id
-      }
-      fromCollective {
-        id
-        slug
-      }
-      collective {
-        id
-        slug
-      }
-      transactions(type: "CREDIT") {
-        id
-        uuid
-      }
-    }
-  }
-`;
+import { getLoggedInUserQuery, getCollectiveToEditQueryFields } from './queries';
 
 export const createUserQuery = gql`
   mutation createUser($user: UserInputType!, $organization: CollectiveInputType, $redirect: String) {
@@ -219,24 +194,6 @@ export const createVirtualCardsMutationQuery = gql`
   }
 `;
 
-export const addCreateOrderMutation = graphql(createOrderQuery, {
-  props: ({ mutate }) => ({
-    createOrder: async order => {
-      return await mutate({
-        variables: { order },
-        update: (cache, { data: { createOrder } }) => {
-          const data = cache.readQuery({
-            query: getCollectiveQuery,
-            variables: { slug: createOrder.collective.slug },
-          });
-          data.Collective.pledges.push({ createOrder });
-          cache.writeQuery({ query: getCollectiveQuery, data });
-        },
-      });
-    },
-  }),
-});
-
 export const addCreateMemberMutation = graphql(createMemberQuery, {
   props: ({ mutate }) => ({
     createMember: (member, collective, role) => mutate({ variables: { member, collective, role } }),
@@ -250,7 +207,6 @@ export const addRemoveMemberMutation = graphql(removeMemberQuery, {
 });
 
 export const addEventMutations = compose(
-  addCreateOrderMutation,
   addCreateMemberMutation,
   addRemoveMemberMutation,
 );


### PR DESCRIPTION
Following on https://github.com/opencollective/opencollective-frontend/pull/1803
Merging this PR will merge it in your own PR, please do so if you agree with these changes. 

I tried to reproduce the issue you mentioned but it didn't happen to me. However I found some issues that I didn't foresee before:

- We were not refetching the same fields than we did for initial query in `createOrder`. That may be the root cause for the issue you encountered. We could have copied them but as this page is very rarely reloaded `refetchQueries` seems like an easier fix than `update` (good job on this one tho, your code was good!)

- `createOrderQuery` was not used outside of `createPledge`. As `update` and `refetchQueries` are deeply linked to the context where they're used, I preferred to move them directly in the component file (`createOrder` could have been used to make a real donation in another component and there would have been no sense to push the order in the `Collectives.pledges`).